### PR TITLE
Add methods for scheduling actions to Interface

### DIFF
--- a/hmpy/interface.py
+++ b/hmpy/interface.py
@@ -1,4 +1,6 @@
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
+
 from .window import InterfaceWindow
 
 
@@ -16,14 +18,42 @@ class Interface:
         self._app = QApplication([])
         self._app.setStyle('Fusion')
         self._root = InterfaceWindow()
+        self._timers = []
 
     def start(self):
         """Launch the GUI"""
         self._root.showMaximized()
         self._app.exec_()
 
+    def after(self, delay, action):
+        """Schedule an action to be executed some time in the future.
+
+        :param delay: Time to wait (in milliseconds)
+        :param action: The function to execute"""
+        timer = QTimer()
+        timer.timeout.connect(action)
+        timer.setInterval(delay)
+        timer.setSingleShot(True)
+        timer.start()
+        self._timers.append(timer)
+
+    def every(self, interval, action):
+        """Schedule an action to be executed at a set interval.
+
+        :param interval: The execution interval (in milliseconds)
+        :param action: The function to execute"""
+        timer = QTimer()
+        timer.timeout.connect(action)
+        timer.setInterval(interval)
+        timer.start()
+        self._timers.append(timer)
+
     def add_view(self, view):
         """Add a view to the Interface
 
         :param view: The view to be added to the Interface"""
         self._root.add_view(view)
+
+    def quit(self):
+        """Close the Interface"""
+        self._app.quit()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -4,12 +4,29 @@ from hmpy import Interface
 
 @pytest.fixture(scope="module")
 def interface():
-    intf = Interface()
-    yield intf
-    intf = None
+    return Interface()
 
 
 def test_multiple_instances(interface):
-    """Test trying to create multiple instances of class Interface"""
+    # Test trying to create multiple instances of class Interface
     with pytest.raises(Exception):
         int2 = Interface()
+
+
+def test_after(interface, qtbot, mocker):
+    # Test that the .after method executes the action only once,
+    # and after the expected delay
+    action = mocker.stub()
+    interface.after(10, action)
+    action.assert_not_called()
+    qtbot.wait(25)
+    action.assert_called_once()
+
+
+def test_every(interface, qtbot, mocker):
+    # Test that the .every method executes the action at the expected interval
+    action = mocker.stub()
+    interface.every(100, action)
+    action.assert_not_called()
+    qtbot.wait(250)
+    assert action.call_count == 2


### PR DESCRIPTION
Base methods for action scheduling.  
Currently there is no way to stop a scheduled event from running, will need to address this in the future.
Was thinking